### PR TITLE
Fix README file typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ The example will be available at: http://localhost:3000
 
 ## A Note about Client Side Javascript ##
 
-This is intended to be used on the server side using Node. While it's possible to utilize AlchemyAPI completely in the browser, it is not recommended. First, this would expose your API key to the world, and this key is a secret. Second, most browsers will block calls to a different domain for security reasons. It's possible to get around this will jsonp, but it's recommended that you proxy any requests to AlchemyAPI through your own server. 
+This is intended to be used on the server side using Node. While it's possible to utilize AlchemyAPI completely in the browser, it is not recommended. First, this would expose your API key to the world, and this key is a secret. Second, most browsers will block calls to a different domain for security reasons. It's possible to get around this with jsonp, but it's recommended that you proxy any requests to AlchemyAPI through your own server. 
 


### PR DESCRIPTION
There was a very small typo in the README file that I noticed and thought it would be good to update. 
The file reads:

```
It's possible to get around this will jsonp...
```

When it should read:

```
It's possible to get around this with jsonp...
```

Here is a screenshot of the typo:
![screen shot 2014-07-19 at 7 00 00 pm](https://cloud.githubusercontent.com/assets/6327569/3636315/b68fc8a8-0fb2-11e4-86c6-62456339b6ca.png)

Thanks so much for a great product! I am just starting to use it.
