### PR TITLE
Add support for /data/GetNews

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   },
   "main": "./alchemyapi.js",
   "dependencies": {
-    "express": "3.4.0",
-    "request": "~2.27.0",
     "consolidate": "~0.9.1",
-    "dustjs-linkedin": "~2.0.3"
+    "dustjs-linkedin": "~2.0.3",
+    "express": "3.4.0",
+    "qs": "^4.0.0",
+    "request": "~2.27.0"
   }
 }


### PR DESCRIPTION
This change does the following:
  - Add referenced endpoints for `/data/GetNews`
  - Add method for `news` that takes start, end, timeSlice, maxResults, and q
  - Add support for "GET" in analyze (might be a little hacky - just let me know)
  - Replace manually building of query string to using the npm module qs - this supports nested JSON. For example `{ a: { b: 'c' } }` becomes `a.b=c` (necessary for the queries that Alchemey supports)