### PR TITLE
Adding value of transactions for any single call on response object

### DIFF
--- a/alchemyapi.js
+++ b/alchemyapi.js
@@ -185,8 +185,8 @@ function AlchemyAPI() {
       res.on('data', function (chunk) { response += chunk; });
       res.on('end', function () {
           FnResp = JSON.parse(response);
-          if (res && res.headers && res.headers['x-alchemyapi-total-transactions']) {
-                FnResp.alchemyapi_total_transactions = Number(res.headers['x-alchemyapi-total-transactions']);
+          if (FnResp && !FnResp.totalTransactions && res && res.headers && res.headers['x-alchemyapi-total-transactions']) {
+              FnResp.totalTransactions = Number(res.headers['x-alchemyapi-total-transactions']);
           }
           callback(FnResp);
       });

--- a/alchemyapi.js
+++ b/alchemyapi.js
@@ -183,7 +183,13 @@ function AlchemyAPI() {
       var response = "";
       res.setEncoding('utf8');
       res.on('data', function (chunk) { response += chunk; });
-      res.on('end', function () { callback(JSON.parse(response)); });
+      res.on('end', function () {
+          FnResp = JSON.parse(response);
+          if (res && res.headers && res.headers['x-alchemyapi-total-transactions']) {
+                FnResp.alchemyapi_total_transactions = Number(res.headers['x-alchemyapi-total-transactions']);
+          }
+          callback(FnResp);
+      });
       res.on('error', function (err) {
         callback({ status:'ERROR', statusInfo: err });
       });


### PR DESCRIPTION
Referring to http://www.alchemyapi.com/products/pricing:

```
What is a transaction? How does AlchemyAPI define those?
In Bluemix, a Transaction = API Event
```

For a customer of AlchemyAPI it should be good to view the number of transactions made by one call.

I made a commit to do this: returning this value on response.
